### PR TITLE
Appl-9541 add support for postmessage calls in webview

### DIFF
--- a/dist/package/Assets/Plugins/WebViewObject.cs
+++ b/dist/package/Assets/Plugins/WebViewObject.cs
@@ -592,6 +592,8 @@ public class WebViewObject : MonoBehaviour
     [DllImport("__Internal")]
     private static extern void _CWebViewPlugin_ClearCache(IntPtr instance, bool includeDiskFiles);
     [DllImport("__Internal")]
+    private static extern void _gree_unity_webview_postMessage(string name, string msg);
+    [DllImport("__Internal")]
     private static extern void _CWebViewPlugin_SetSuspended(IntPtr instance, bool suspended);
 #elif UNITY_WEBGL
     [DllImport("__Internal")]
@@ -1148,7 +1150,7 @@ public class WebViewObject : MonoBehaviour
     {
 #if UNITY_WEBGL
 #if !UNITY_EDITOR
-        _gree_unity_webview_evaluateJS(name, js);
+        _gree_unity_webview_postMessage(name, js);
 #endif
 #elif UNITY_WEBPLAYER
         Application.ExternalCall("unityWebView.evaluateJS", name, js);

--- a/dist/package/Assets/Plugins/WebViewObject.cs
+++ b/dist/package/Assets/Plugins/WebViewObject.cs
@@ -1169,6 +1169,9 @@ public class WebViewObject : MonoBehaviour
 
 public void PostMessage(string msg)
     {
+#if !UNITY_WEBGL || !UNITY_WEBPLAYER
+		Debug.LogWarning($"PostMessage not supported on {Application.platform}. Using fallback EvaluateJS");
+#endif
 #if UNITY_WEBGL
 #if !UNITY_EDITOR
         _gree_unity_webview_postMessage(name, msg);

--- a/dist/package/Assets/Plugins/WebViewObject.cs
+++ b/dist/package/Assets/Plugins/WebViewObject.cs
@@ -941,14 +941,14 @@ public class WebViewObject : MonoBehaviour
             bg.gameObject.active = v;
         }
 #endif
+#if !UNITY_WEBGL
         if (GetVisibility() && !v)
         {
-            Debug.LogError($"APPL-9540 trying to call EvaluateJS on platform {Application.platform}");
             EvaluateJS("if (document && document.activeElement) document.activeElement.blur();");
         }
+#endif
 #if UNITY_WEBGL
 #if !UNITY_EDITOR
-        Debug.Log($"APPL-9540 reached correct branch in SetVisibility {Application.platform}");
         _gree_unity_webview_setVisibility(name, v);
 #endif
 #elif UNITY_WEBPLAYER

--- a/dist/package/Assets/Plugins/WebViewObject.cs
+++ b/dist/package/Assets/Plugins/WebViewObject.cs
@@ -1150,7 +1150,8 @@ public class WebViewObject : MonoBehaviour
     {
 #if UNITY_WEBGL
 #if !UNITY_EDITOR
-        _gree_unity_webview_postMessage(name, js);
+        //_gree_unity_webview_postMessage(name, js);
+		_gree_unity_webview_evaluateJS(name, js);
 #endif
 #elif UNITY_WEBPLAYER
         Application.ExternalCall("unityWebView.evaluateJS", name, js);

--- a/dist/package/Assets/Plugins/WebViewObject.cs
+++ b/dist/package/Assets/Plugins/WebViewObject.cs
@@ -1169,7 +1169,7 @@ public class WebViewObject : MonoBehaviour
 
 public void PostMessage(string msg)
     {
-#if !UNITY_WEBGL || !UNITY_WEBPLAYER
+#if !UNITY_WEBGL && !UNITY_WEBPLAYER
 		Debug.LogWarning($"PostMessage not supported on {Application.platform}. Using fallback EvaluateJS");
 #endif
 #if UNITY_WEBGL

--- a/dist/package/Assets/Plugins/WebViewObject.cs
+++ b/dist/package/Assets/Plugins/WebViewObject.cs
@@ -1184,12 +1184,12 @@ public void PostMessage(string msg)
         if (webView == IntPtr.Zero)
             return;
 //TODO: decalre/implement _CWebViewPlugin_PostMessage
-        _CWebViewPlugin_EvaluateJS(webView, js);
+        _CWebViewPlugin_EvaluateJS(webView, msg);
 #elif UNITY_ANDROID
-//TODO: Implemenate EvaluateJS for android
+//TODO: Implement EvaluateJS for android
         if (webView == null)
             return;
-        webView.Call("EvaluateJS", js);
+        webView.Call("EvaluateJS", msg);
 #endif
     }
 

--- a/dist/package/Assets/Plugins/WebViewObject.cs
+++ b/dist/package/Assets/Plugins/WebViewObject.cs
@@ -943,10 +943,12 @@ public class WebViewObject : MonoBehaviour
 #endif
         if (GetVisibility() && !v)
         {
+            Debug.LogError($"APPL-9540 trying to call EvaluateJS on platform {Application.platform}")
             EvaluateJS("if (document && document.activeElement) document.activeElement.blur();");
         }
 #if UNITY_WEBGL
 #if !UNITY_EDITOR
+        Debug.Log($"APPL-9540 reached correct branch in SetVisibility {Application.platform}");
         _gree_unity_webview_setVisibility(name, v);
 #endif
 #elif UNITY_WEBPLAYER

--- a/dist/package/Assets/Plugins/WebViewObject.cs
+++ b/dist/package/Assets/Plugins/WebViewObject.cs
@@ -592,8 +592,6 @@ public class WebViewObject : MonoBehaviour
     [DllImport("__Internal")]
     private static extern void _CWebViewPlugin_ClearCache(IntPtr instance, bool includeDiskFiles);
     [DllImport("__Internal")]
-    private static extern void _gree_unity_webview_postMessage(string name, string msg);
-    [DllImport("__Internal")]
     private static extern void _CWebViewPlugin_SetSuspended(IntPtr instance, bool suspended);
 #elif UNITY_WEBGL
     [DllImport("__Internal")]
@@ -606,6 +604,8 @@ public class WebViewObject : MonoBehaviour
     private static extern void _gree_unity_webview_loadURL(string name, string url);
     [DllImport("__Internal")]
     private static extern void _gree_unity_webview_evaluateJS(string name, string js);
+    [DllImport("__Internal")]
+    private static extern void _gree_unity_webview_postMessage(string name, string msg);
     [DllImport("__Internal")]
     private static extern void _gree_unity_webview_destroy(string name);
 #endif
@@ -1150,8 +1150,7 @@ public class WebViewObject : MonoBehaviour
     {
 #if UNITY_WEBGL
 #if !UNITY_EDITOR
-        //_gree_unity_webview_postMessage(name, js);
-		_gree_unity_webview_evaluateJS(name, js);
+        _gree_unity_webview_postMessage(name, js);
 #endif
 #elif UNITY_WEBPLAYER
         Application.ExternalCall("unityWebView.evaluateJS", name, js);

--- a/dist/package/Assets/Plugins/WebViewObject.cs
+++ b/dist/package/Assets/Plugins/WebViewObject.cs
@@ -943,7 +943,7 @@ public class WebViewObject : MonoBehaviour
 #endif
         if (GetVisibility() && !v)
         {
-            Debug.LogError($"APPL-9540 trying to call EvaluateJS on platform {Application.platform}")
+            Debug.LogError($"APPL-9540 trying to call EvaluateJS on platform {Application.platform}");
             EvaluateJS("if (document && document.activeElement) document.activeElement.blur();");
         }
 #if UNITY_WEBGL

--- a/dist/package/Assets/Plugins/WebViewObject.cs
+++ b/dist/package/Assets/Plugins/WebViewObject.cs
@@ -1150,7 +1150,7 @@ public class WebViewObject : MonoBehaviour
     {
 #if UNITY_WEBGL
 #if !UNITY_EDITOR
-        _gree_unity_webview_postMessage(name, js);
+        _gree_unity_webview_evaluateJS(name, js);
 #endif
 #elif UNITY_WEBPLAYER
         Application.ExternalCall("unityWebView.evaluateJS", name, js);
@@ -1166,6 +1166,30 @@ public class WebViewObject : MonoBehaviour
         webView.Call("EvaluateJS", js);
 #endif
     }
+
+public void PostMessage(string msg)
+    {
+#if UNITY_WEBGL
+#if !UNITY_EDITOR
+        _gree_unity_webview_postMessage(name, msg);
+#endif
+#elif UNITY_WEBPLAYER
+        Application.ExternalCall("unityWebView.postMessage", name, msg);
+#elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN || UNITY_EDITOR_LINUX
+        //TODO: UNSUPPORTED
+#elif UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IPHONE
+        if (webView == IntPtr.Zero)
+            return;
+//TODO: decalre/implement _CWebViewPlugin_PostMessage
+        _CWebViewPlugin_EvaluateJS(webView, js);
+#elif UNITY_ANDROID
+//TODO: Implemenate EvaluateJS for android
+        if (webView == null)
+            return;
+        webView.Call("EvaluateJS", js);
+#endif
+    }
+
 
     public int Progress()
     {

--- a/dist/package/Assets/Plugins/unity-webview-webgl-plugin.jslib
+++ b/dist/package/Assets/Plugins/unity-webview-webgl-plugin.jslib
@@ -24,6 +24,11 @@ mergeInto(LibraryManager.library, {
 		unityWebView.evaluateJS(stringify(name), stringify(js));
 	},
 
+	_gree_unity_webview_postMessage: function(name, msg) {
+		var stringify = (UTF8ToString === undefined) ? Pointer_stringify : UTF8ToString;
+		unityWebView.postMessage(stringify(name), stringify(msg));
+	},
+
 	_gree_unity_webview_destroy: function(name) {
 		var stringify = (UTF8ToString === undefined) ? Pointer_stringify : UTF8ToString;
 		unityWebView.destroy(stringify(name));

--- a/dist/package/Assets/WebGLTemplates/unity-webview-2020/unity-webview.js
+++ b/dist/package/Assets/WebGLTemplates/unity-webview-2020/unity-webview.js
@@ -94,6 +94,16 @@ var unityWebView =
         }
     },
 
+    postMessage: function (name, msg) {
+        $iframe = this.iframe(name);
+        if ($iframe.attr('loaded') === 'true') {
+            $iframe[0].contentWindow.postMessage(msg, '*');
+        } else {
+            $iframe.on('load', function(){
+                $(this)[0].contentWindow.postMessage(msg, '*');
+            });
+        }
+    },
     destroy: function (name) {
         this.iframe(name).parent().parent().remove();
     },
@@ -103,3 +113,10 @@ var unityWebView =
     },
 
 };
+
+window.addEventListener(
+    'message',
+    function(event) {
+        unityWebView.sendMessage('WebViewObject', event.data);
+    },
+    false);


### PR DESCRIPTION
as per changes indicated in https://github.com/gree/unity-webview/issues/1088, this aims to add support for PostMessage calls with which to replace javascript `eval` calls.

Note that native APIs do not enforce CSP as they are acting outside of the browser context. A such, EvaluateJS can still be used in native iOS/Android context.

This is confirmed "as intended" on [W3C/CSP discussion group.](https://github.com/w3c/webappsec-csp/issues/570)